### PR TITLE
Use idiomatic lazy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 {
   'forest-nvim/maple.nvim',
-  config = function()
-    require('maple').setup({
+  opts = {
       -- Your configuration options here
-    })
-  end
+    }
 }
 ```
 


### PR DESCRIPTION
To cite from the [docs](https://lazy.folke.io/spec)

> Always use opts instead of config when possible. config is almost never needed.